### PR TITLE
Fix kafka wait script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,5 +176,5 @@ services:
       CONNECT_ZOOKEEPER_CONNECT: zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
       CONNECTOR_PROPERTY_FILE_PREFIX: 'sink-timescale'
       KAFKA_HEAP_OPTS: '-Xms256m -Xmx768m'
-      KAFKA_BROKERS: 1
+      KAFKA_BROKERS: 3
       CONNECT_LOG4J_LOGGERS: 'org.reflections=ERROR'

--- a/docker/kafka-wait
+++ b/docker/kafka-wait
@@ -18,7 +18,7 @@ max_timeout=32
 tries=10
 timeout=1
 while true; do
-    ZOOKEEPER_CHECK=$(zookeeper-shell ${CONNECT_ZOOKEEPER_CONNECT} <<< "ls /brokers/ids" | tail -2 | head -1)
+    ZOOKEEPER_CHECK=$(zookeeper-shell ${CONNECT_ZOOKEEPER_CONNECT} <<< "ls /brokers/ids" | tail -1)
     echo "Zookeeper response: ${ZOOKEEPER_CHECK}"
     # ZOOKEEPER_CHECK="${ZOOKEEPER_CHECK##*$'\n'}"
     ZOOKEEPER_CHECK="$(echo -e "${ZOOKEEPER_CHECK}" | tr -d '[:space:]'  | tr -d '['  | tr -d ']')"


### PR DESCRIPTION
- Fixes kafka wait script unable to get kafka brokers:
`zookeeper-shell zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181 ls /brokers/ids | tail -2 | head -1`
returns
```WatchedEvent state:SyncConnected type:None path:null```
when it should be returning
`[1, 2, 3]`

This was working because I set `KAFKA_BROKERS` to 1 for testing purposes, which caused an issue with the Kubernetes deployment.