### PR TITLE
Sync changes with base

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,28 @@
+## Problem
+
+
+## Solution
+
+
+<!--- Mark x in the box. -->
+##### Does this solution apply anywhere else?
+- [ ] yes
+- [ ] no
+
+##### If yes, where?
+
+
+## Test Strategy
+
+
+<!--- Mark x in the box for all that apply. -->
+##### Testing done:
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] System tests
+- [ ] Manual tests
+
+## Release Plan
+<!--- Describe the release plan for this feature. -->
+<!-- Are you backporting or merging to master? -->
+<!-- If you are reverting or rolling back, is it safe? --> 

--- a/kafka-connect-jdbc/checkstyle/suppressions.xml
+++ b/kafka-connect-jdbc/checkstyle/suppressions.xml
@@ -22,5 +22,5 @@
               files="(DataConverter|GenericDatabaseDialect|JdbcSourceTask).java"/>
 
     <suppress checks="ParameterNumber"
-              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect).java"/>
+              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect).java"/>
 </suppressions>

--- a/kafka-connect-jdbc/pom.xml
+++ b/kafka-connect-jdbc/pom.xml
@@ -145,6 +145,12 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.zonky.test</groupId>
             <artifactId>embedded-postgres</artifactId>

--- a/kafka-connect-jdbc/pom.xml
+++ b/kafka-connect-jdbc/pom.xml
@@ -149,6 +149,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>confluent-log4j</artifactId>
+            <version>1.2.17-cp2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -311,14 +311,70 @@ public interface DatabaseDialect extends ConnectionProvider {
   /**
    * Build the INSERT prepared statement expression for the given table and its columns.
    *
+   * <p>This method is only called by the default implementation of
+   * {@link #buildInsertStatement(TableId, Collection, Collection, TableDefinition)}, since
+   * many dialects implement this variant of the method. However, overriding
+   * {@link #buildInsertStatement(TableId, Collection, Collection, TableDefinition)} is suggested.
+   *
    * @param table         the identifier of the table; may not be null
    * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
    *                      but may be empty
    * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
    *                      be empty
    * @return the INSERT statement; may not be null
+   * @deprecated use {@link #buildInsertStatement(TableId, Collection, Collection, TableDefinition)}
    */
+  @Deprecated
   String buildInsertStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns,
+      Collection<ColumnId> nonKeyColumns
+  );
+
+  /**
+   * Build the INSERT prepared statement expression for the given table and its columns.
+   *
+   * <p>By default this method calls
+   * {@link #buildInsertStatement(TableId, Collection, Collection)} to maintain backward
+   * compatibility with older versions. Subclasses that override this method do not need to
+   * override {@link #buildInsertStatement(TableId, Collection, Collection)}.
+   *
+   * @param table         the identifier of the table; may not be null
+   * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
+   *                      but may be empty
+   * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
+   *                      be empty
+   * @param definition    the table definition; may be null if unknown
+   * @return the INSERT statement; may not be null
+   */
+  default String buildInsertStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns,
+      Collection<ColumnId> nonKeyColumns,
+      TableDefinition definition
+  ) {
+    return buildInsertStatement(table, keyColumns, nonKeyColumns);
+  }
+
+  /**
+   * Build the UPDATE prepared statement expression for the given table and its columns. Variables
+   * for each key column should also appear in the WHERE clause of the statement.
+   *
+   * <p>This method is only called by the default implementation of
+   * {@link #buildUpdateStatement(TableId, Collection, Collection, TableDefinition)}, since
+   * many dialects implement this variant of the method. However, overriding
+   * {@link #buildUpdateStatement(TableId, Collection, Collection, TableDefinition)} is suggested.
+   *
+   * @param table         the identifier of the table; may not be null
+   * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
+   *                      but may be empty
+   * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
+   *                      be empty
+   * @return the UPDATE statement; may not be null
+   * @deprecated use {@link #buildUpdateStatement(TableId, Collection, Collection, TableDefinition)}
+   */
+  @Deprecated
+  String buildUpdateStatement(
       TableId table,
       Collection<ColumnId> keyColumns,
       Collection<ColumnId> nonKeyColumns
@@ -328,14 +384,50 @@ public interface DatabaseDialect extends ConnectionProvider {
    * Build the UPDATE prepared statement expression for the given table and its columns. Variables
    * for each key column should also appear in the WHERE clause of the statement.
    *
+   * <p>By default this method calls
+   * {@link #buildUpdateStatement(TableId, Collection, Collection)} to maintain backward
+   * compatibility with older versions. Subclasses that override this method do not need to
+   * override {@link #buildUpdateStatement(TableId, Collection, Collection)}.
+   *
    * @param table         the identifier of the table; may not be null
    * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
    *                      but may be empty
    * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
    *                      be empty
+   * @param definition    the table definition; may be null if unknown
    * @return the UPDATE statement; may not be null
    */
-  String buildUpdateStatement(
+  default String buildUpdateStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns,
+      Collection<ColumnId> nonKeyColumns,
+      TableDefinition definition
+  ) {
+    return buildUpdateStatement(table, keyColumns, nonKeyColumns);
+  }
+
+  /**
+   * Build the UPSERT or MERGE prepared statement expression to either insert a new record into the
+   * given table or update an existing record in that table Variables for each key column should
+   * also appear in the WHERE clause of the statement.
+   *
+   * <p>This method is only called by the default implementation of
+   * {@link #buildUpsertQueryStatement(TableId, Collection, Collection, TableDefinition)}, since
+   * many dialects implement this variant of the method. However, overriding
+   * {@link #buildUpsertQueryStatement(TableId, Collection, Collection, TableDefinition)}
+   * is suggested.
+   *
+   * @param table         the identifier of the table; may not be null
+   * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
+   *                      but may be empty
+   * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
+   *                      be empty
+   * @return the upsert/merge statement; may not be null
+   * @throws UnsupportedOperationException if the dialect does not support upserts
+   * @deprecated use {@link #buildUpsertQueryStatement(TableId, Collection, Collection)}
+   */
+  @Deprecated
+  String buildUpsertQueryStatement(
       TableId table,
       Collection<ColumnId> keyColumns,
       Collection<ColumnId> nonKeyColumns
@@ -346,19 +438,28 @@ public interface DatabaseDialect extends ConnectionProvider {
    * given table or update an existing record in that table Variables for each key column should
    * also appear in the WHERE clause of the statement.
    *
+   * <p>By default this method calls
+   * {@link #buildUpsertQueryStatement(TableId, Collection, Collection)} to maintain backward
+   * compatibility with older versions. Subclasses that override this method do not need to
+   * override {@link #buildUpsertQueryStatement(TableId, Collection, Collection)}.
+   *
    * @param table         the identifier of the table; may not be null
    * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
    *                      but may be empty
    * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
    *                      be empty
+   * @param definition    the table definition; may be null if unknown
    * @return the upsert/merge statement; may not be null
    * @throws UnsupportedOperationException if the dialect does not support upserts
    */
-  String buildUpsertQueryStatement(
+  default String buildUpsertQueryStatement(
       TableId table,
       Collection<ColumnId> keyColumns,
-      Collection<ColumnId> nonKeyColumns
-  );
+      Collection<ColumnId> nonKeyColumns,
+      TableDefinition definition
+  ) {
+    return buildUpsertQueryStatement(table, keyColumns, nonKeyColumns);
+  }
 
   /**
    * Build the DELETE prepared statement expression for the given table and its columns. Variables

--- a/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -15,8 +15,10 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.util.Collections;
 import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -31,6 +33,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
@@ -40,6 +44,7 @@ import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.ExpressionBuilder.Transform;
 import io.confluent.connect.jdbc.util.IdentifierRules;
+import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableId;
 
 /**
@@ -63,6 +68,18 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   static final String JSON_TYPE_NAME = "json";
   static final String JSONB_TYPE_NAME = "jsonb";
+  static final String UUID_TYPE_NAME = "uuid";
+
+  /**
+   * Define the PG datatypes that require casting upon insert/update statements.
+   */
+  private static final Set<String> CAST_TYPES = Collections.unmodifiableSet(
+      Utils.mkSet(
+          JSON_TYPE_NAME,
+          JSONB_TYPE_NAME,
+          UUID_TYPE_NAME
+      )
+  );
 
   /**
    * Create a new dialect instance with the given connector configuration.
@@ -130,6 +147,18 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           );
           return fieldName;
         }
+
+        if (UUID.class.getName().equals(columnDefn.classNameForType())) {
+          builder.field(
+                  fieldName,
+                  columnDefn.isOptional()
+                          ?
+                          Schema.OPTIONAL_STRING_SCHEMA :
+                          Schema.STRING_SCHEMA
+          );
+          return fieldName;
+        }
+
         break;
       }
       default:
@@ -165,6 +194,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       }
       case Types.OTHER: {
         if (isJsonType(columnDefn)) {
+          return rs -> rs.getString(col);
+        }
+
+        if (UUID.class.getName().equals(columnDefn.classNameForType())) {
           return rs -> rs.getString(col);
         }
         break;
@@ -223,10 +256,60 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   @Override
+  public String buildInsertStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns,
+      Collection<ColumnId> nonKeyColumns,
+      TableDefinition definition
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("INSERT INTO ");
+    builder.append(table);
+    builder.append(" (");
+    builder.appendList()
+           .delimitedBy(",")
+           .transformedBy(ExpressionBuilder.columnNames())
+           .of(keyColumns, nonKeyColumns);
+    builder.append(") VALUES (");
+    builder.appendList()
+           .delimitedBy(",")
+           .transformedBy(this.columnValueVariables(definition))
+           .of(keyColumns, nonKeyColumns);
+    builder.append(")");
+    return builder.toString();
+  }
+
+  @Override
+  public String buildUpdateStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns,
+      Collection<ColumnId> nonKeyColumns,
+      TableDefinition definition
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("UPDATE ");
+    builder.append(table);
+    builder.append(" SET ");
+    builder.appendList()
+           .delimitedBy(", ")
+           .transformedBy(this.columnNamesWithValueVariables(definition))
+           .of(nonKeyColumns);
+    if (!keyColumns.isEmpty()) {
+      builder.append(" WHERE ");
+      builder.appendList()
+             .delimitedBy(" AND ")
+             .transformedBy(ExpressionBuilder.columnNamesWith(" = ?"))
+             .of(keyColumns);
+    }
+    return builder.toString();
+  }
+
+  @Override
   public String buildUpsertQueryStatement(
       TableId table,
       Collection<ColumnId> keyColumns,
-      Collection<ColumnId> nonKeyColumns
+      Collection<ColumnId> nonKeyColumns,
+      TableDefinition definition
   ) {
     final Transform<ColumnId> transform = (builder, col) -> {
       builder.appendColumnName(col.name())
@@ -243,7 +326,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
            .transformedBy(ExpressionBuilder.columnNames())
            .of(keyColumns, nonKeyColumns);
     builder.append(") VALUES (");
-    builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
+    builder.appendList()
+           .delimitedBy(",")
+           .transformedBy(this.columnValueVariables(definition))
+           .of(keyColumns, nonKeyColumns);
     builder.append(") ON CONFLICT (");
     builder.appendList()
            .delimitedBy(",")
@@ -276,4 +362,62 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
   }
 
+  /**
+   * Return the transform that produces an assignment expression each with the name of one of the
+   * columns and the prepared statement variable. PostgreSQL may require the variable to have a
+   * type suffix, such as {@code ?::uuid}.
+   *
+   * @param defn the table definition; may be null if unknown
+   * @return the transform that produces the assignment expression for use within a prepared
+   *         statement; never null
+   */
+  protected Transform<ColumnId> columnNamesWithValueVariables(TableDefinition defn) {
+    return (builder, columnId) -> {
+      builder.appendColumnName(columnId.name());
+      builder.append(" = ?");
+      builder.append(valueTypeCast(defn, columnId));
+    };
+  }
+
+  /**
+   * Return the transform that produces a prepared statement variable for each of the columns.
+   * PostgreSQL may require the variable to have a type suffix, such as {@code ?::uuid}.
+   *
+   * @param defn the table definition; may be null if unknown
+   * @return the transform that produces the variable expression for each column; never null
+   */
+  protected Transform<ColumnId> columnValueVariables(TableDefinition defn) {
+    return (builder, columnId) -> {
+      builder.append("?");
+      builder.append(valueTypeCast(defn, columnId));
+    };
+  }
+
+  /**
+   * Return the typecast expression that can be used as a suffix for a value variable of the
+   * given column in the defined table.
+   *
+   * <p>This method returns a blank string except for those column types that require casting
+   * when set with literal values. For example, a column of type {@code uuid} must be cast when
+   * being bound with with a {@code varchar} literal, since a UUID value cannot be bound directly.
+   *
+   * @param tableDefn the table definition; may be null if unknown
+   * @param columnId  the column within the table; may not be null
+   * @return the cast expression, or an empty string; never null
+   */
+  protected String valueTypeCast(TableDefinition tableDefn, ColumnId columnId) {
+    if (tableDefn != null) {
+      ColumnDefinition defn = tableDefn.definitionForColumn(columnId.name());
+      if (defn != null) {
+        String typeName = defn.typeName(); // database-specific
+        if (typeName != null) {
+          typeName = typeName.toLowerCase();
+          if (CAST_TYPES.contains(typeName)) {
+            return "::" + typeName;
+          }
+        }
+      }
+    }
+    return "";
+  }
 }

--- a/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialect.java
+++ b/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialect.java
@@ -60,6 +60,11 @@ public class SapHanaDatabaseDialect extends GenericDatabaseDialect {
   public SapHanaDatabaseDialect(AbstractConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
   }
+  
+  @Override
+  protected String currentTimestampDatabaseQuery() {
+    return "SELECT CURRENT_TIMESTAMP FROM DUMMY";
+  }
 
   @Override
   protected String checkConnectionQuery() {

--- a/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
+++ b/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
@@ -64,11 +64,9 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
   }
 
   @Override
-  public List<String> buildCreateTableStatements(
-          TableId table,
-          Collection<SinkRecordField> fields
-  ) {
-    // This would create the schema and table then convert the table to a hyper table.
+  public List<String> buildCreateTableStatements(TableId table, Collection<SinkRecordField> fields) {
+    // This would create the schema and table then convert the table to a hyper
+    // table.
     List<String> sqlQueries = new ArrayList<>();
     if (table.schemaName() != null) {
       sqlQueries.add(buildCreateSchemaStatement(table));
@@ -79,23 +77,18 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
     return sqlQueries;
   }
 
-
-  public String buildCreateHyperTableStatement(
-          TableId table
-  ) {
+  public String buildCreateHyperTableStatement(TableId table) {
     ExpressionBuilder builder = expressionBuilder();
 
     builder.append("SELECT create_hypertable('");
     builder.append(table);
-    builder.append("', 'time', migrate_data => TRUE, chunk_time_interval => INTERVAL ');
+    builder.append("', 'time', migrate_data => TRUE, chunk_time_interval => INTERVAL '");
     builder.append(CHUNK_TIME_INTERVAL);
-    builder.append(');");
+    builder.append("');");
     return builder.toString();
   }
 
-  public String buildCreateSchemaStatement(
-          TableId table
-  ) {
+  public String buildCreateSchemaStatement(TableId table) {
     ExpressionBuilder builder = expressionBuilder();
 
     builder.append("CREATE SCHEMA IF NOT EXISTS ");
@@ -104,11 +97,9 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
   }
 
   @Override
-  public void applyDdlStatements(
-          Connection connection,
-          List<String> statements
-  ) throws SQLException {
-    // This overrides the function by catching 'result was returned' error thrown by PSQL
+  public void applyDdlStatements(Connection connection, List<String> statements) throws SQLException {
+    // This overrides the function by catching 'result was returned' error thrown by
+    // PSQL
     // when creating hypertables
     try {
       super.applyDdlStatements(connection, statements);
@@ -129,21 +120,13 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
   }
 
   @Override
-  protected void formatColumnValue(
-          ExpressionBuilder builder,
-          String schemaName,
-          Map<String, String> schemaParameters,
-          Schema.Type type,
-          Object value
-  ) {
+  protected void formatColumnValue(ExpressionBuilder builder, String schemaName, Map<String, String> schemaParameters,
+      Schema.Type type, Object value) {
     if (schemaName == org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME) {
-      builder.appendStringQuoted(
-              DateTimeUtils.formatTimestamptz((java.util.Date) value, super.timeZone())
-      );
+      builder.appendStringQuoted(DateTimeUtils.formatTimestamptz((java.util.Date) value, super.timeZone()));
     } else {
       super.formatColumnValue(builder, schemaName, schemaParameters, type, value);
     }
   }
-
 
 }

--- a/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -262,13 +262,14 @@ public class BufferedRecords {
     }
   }
 
-  private String getInsertSql() {
+  private String getInsertSql() throws SQLException {
     switch (config.insertMode) {
       case INSERT:
         return dbDialect.buildInsertStatement(
             tableId,
             asColumns(fieldsMetadata.keyFieldNames),
-            asColumns(fieldsMetadata.nonKeyFieldNames)
+            asColumns(fieldsMetadata.nonKeyFieldNames),
+            dbStructure.tableDefinition(connection, tableId)
         );
       case UPSERT:
         if (fieldsMetadata.keyFieldNames.isEmpty()) {
@@ -282,7 +283,8 @@ public class BufferedRecords {
           return dbDialect.buildUpsertQueryStatement(
               tableId,
               asColumns(fieldsMetadata.keyFieldNames),
-              asColumns(fieldsMetadata.nonKeyFieldNames)
+              asColumns(fieldsMetadata.nonKeyFieldNames),
+              dbStructure.tableDefinition(connection, tableId)
           );
         } catch (UnsupportedOperationException e) {
           throw new ConnectException(String.format(
@@ -295,7 +297,8 @@ public class BufferedRecords {
         return dbDialect.buildUpdateStatement(
             tableId,
             asColumns(fieldsMetadata.keyFieldNames),
-            asColumns(fieldsMetadata.nonKeyFieldNames)
+            asColumns(fieldsMetadata.nonKeyFieldNames),
+            dbStructure.tableDefinition(connection, tableId)
         );
       default:
         throw new ConnectException("Invalid insert mode");

--- a/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -75,6 +75,27 @@ public class DbStructure {
   }
 
   /**
+   * Get the definition for the table with the given ID. This returns a cached definition if
+   * there is one; otherwise, it reads the definition from the database
+   *
+   * @param connection the connection that may be used to fetch the table definition if not
+   *                   already known; may not be null
+   * @param tableId    the ID of the table; may not be null
+   * @return the table definition; or null if the table does not exist
+   * @throws SQLException if there is an error getting the definition from the database
+   */
+  public TableDefinition tableDefinition(
+      Connection connection,
+      TableId tableId
+  ) throws SQLException {
+    TableDefinition defn = tableDefns.get(connection, tableId);
+    if (defn != null) {
+      return defn;
+    }
+    return tableDefns.refresh(connection, tableId);
+  }
+
+  /**
    * @throws SQLException if CREATE failed
    */
   void create(

--- a/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -47,9 +47,16 @@ public class JdbcDbWriter {
     this.dbDialect = dbDialect;
     this.dbStructure = dbStructure;
 
-    this.cachedConnectionProvider = new CachedConnectionProvider(this.dbDialect) {
+    this.cachedConnectionProvider = connectionProvider(
+        config.connectionAttempts,
+        config.connectionBackoffMs
+    );
+  }
+
+  protected CachedConnectionProvider connectionProvider(int maxConnAttempts, long retryBackoff) {
+    return new CachedConnectionProvider(this.dbDialect, maxConnAttempts, retryBackoff) {
       @Override
-      protected void onConnect(Connection connection) throws SQLException {
+      protected void onConnect(final Connection connection) throws SQLException {
         log.info("JdbcDbWriter Connected");
         connection.setAutoCommit(false);
       }

--- a/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -85,6 +85,24 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String CONNECTION_PASSWORD_DOC = "JDBC connection password.";
   private static final String CONNECTION_PASSWORD_DISPLAY = "JDBC Password";
 
+  public static final String CONNECTION_ATTEMPTS =
+      JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_CONFIG;
+  private static final String CONNECTION_ATTEMPTS_DOC =
+      JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_DOC;
+  private static final String CONNECTION_ATTEMPTS_DISPLAY =
+      JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_DISPLAY;
+  public static final int CONNECTION_ATTEMPTS_DEFAULT =
+      JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_DEFAULT;
+
+  public static final String CONNECTION_BACKOFF =
+      JdbcSourceConnectorConfig.CONNECTION_BACKOFF_CONFIG;
+  private static final String CONNECTION_BACKOFF_DOC =
+      JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DOC;
+  private static final String CONNECTION_BACKOFF_DISPLAY =
+      JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DISPLAY;
+  public static final long CONNECTION_BACKOFF_DEFAULT =
+      JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DEFAULT;
+
   public static final String TABLE_NAME_FORMAT = "table.name.format";
   private static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";
   private static final String TABLE_NAME_FORMAT_DOC =
@@ -299,6 +317,28 @@ public class JdbcSinkConfig extends AbstractConfig {
             DIALECT_NAME_DISPLAY,
             DatabaseDialectRecommender.INSTANCE
         )
+        .define(
+            CONNECTION_ATTEMPTS,
+            ConfigDef.Type.INT,
+            CONNECTION_ATTEMPTS_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            ConfigDef.Importance.LOW,
+            CONNECTION_ATTEMPTS_DOC,
+            CONNECTION_GROUP,
+            5,
+            ConfigDef.Width.SHORT,
+            CONNECTION_ATTEMPTS_DISPLAY
+        ).define(
+            CONNECTION_BACKOFF,
+            ConfigDef.Type.LONG,
+            CONNECTION_BACKOFF_DEFAULT,
+            ConfigDef.Importance.LOW,
+            CONNECTION_BACKOFF_DOC,
+            CONNECTION_GROUP,
+            6,
+            ConfigDef.Width.SHORT,
+            CONNECTION_BACKOFF_DISPLAY
+        )
         // Writes
         .define(
             INSERT_MODE,
@@ -476,6 +516,8 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final String connectionUrl;
   public final String connectionUser;
   public final String connectionPassword;
+  public final int connectionAttempts;
+  public final long connectionBackoffMs;
   public final String tableNameFormat;
   public final String schemaNameFormat;
   public final int batchSize;
@@ -498,6 +540,8 @@ public class JdbcSinkConfig extends AbstractConfig {
     connectionUrl = getString(CONNECTION_URL);
     connectionUser = getString(CONNECTION_USER);
     connectionPassword = getPasswordValue(CONNECTION_PASSWORD);
+    connectionAttempts = getInt(CONNECTION_ATTEMPTS);
+    connectionBackoffMs = getLong(CONNECTION_BACKOFF);
     tableNameFormat = getString(TABLE_NAME_FORMAT).trim();
     schemaNameFormat = getString(SCHEMA_NAME_FORMAT).trim();
     batchSize = getInt(BATCH_SIZE);

--- a/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
+++ b/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
@@ -65,6 +65,9 @@ public interface RecordValidator {
     if (config.deleteEnabled) {
       // When delete is enabled, we need a key
       keyValidator = keyValidator.and(requiresKey);
+    } else {
+      // When delete is disabled, we need non-tombstone values
+      valueValidator = valueValidator.and(requiresValue);
     }
 
     // Compose the validator that may or may be NO_OP

--- a/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -51,7 +51,9 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   private static final Logger LOG = LoggerFactory.getLogger(JdbcSourceConnectorConfig.class);
 
-  public static final String CONNECTION_URL_CONFIG = "connection.url";
+  public static final String CONNECTION_PREFIX = "connection.";
+
+  public static final String CONNECTION_URL_CONFIG = CONNECTION_PREFIX + "url";
   private static final String CONNECTION_URL_DOC =
       "JDBC connection URL.\n"
           + "For example: ``jdbc:oracle:thin:@localhost:1521:orclpdb1``, "
@@ -60,25 +62,25 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           + "databaseName=db_name``";
   private static final String CONNECTION_URL_DISPLAY = "JDBC URL";
 
-  public static final String CONNECTION_USER_CONFIG = "connection.user";
+  public static final String CONNECTION_USER_CONFIG = CONNECTION_PREFIX + "user";
   private static final String CONNECTION_USER_DOC = "JDBC connection user.";
   private static final String CONNECTION_USER_DISPLAY = "JDBC User";
 
-  public static final String CONNECTION_PASSWORD_CONFIG = "connection.password";
+  public static final String CONNECTION_PASSWORD_CONFIG = CONNECTION_PREFIX + "password";
   private static final String CONNECTION_PASSWORD_DOC = "JDBC connection password.";
   private static final String CONNECTION_PASSWORD_DISPLAY = "JDBC Password";
 
-  public static final String CONNECTION_ATTEMPTS_CONFIG = "connection.attempts";
-  private static final String CONNECTION_ATTEMPTS_DOC
+  public static final String CONNECTION_ATTEMPTS_CONFIG = CONNECTION_PREFIX + "attempts";
+  public static final String CONNECTION_ATTEMPTS_DOC
       = "Maximum number of attempts to retrieve a valid JDBC connection. "
           + "Must be a positive integer.";
-  private static final String CONNECTION_ATTEMPTS_DISPLAY = "JDBC connection attempts";
+  public static final String CONNECTION_ATTEMPTS_DISPLAY = "JDBC connection attempts";
   public static final int CONNECTION_ATTEMPTS_DEFAULT = 3;
 
-  public static final String CONNECTION_BACKOFF_CONFIG = "connection.backoff.ms";
-  private static final String CONNECTION_BACKOFF_DOC
+  public static final String CONNECTION_BACKOFF_CONFIG = CONNECTION_PREFIX + "backoff.ms";
+  public static final String CONNECTION_BACKOFF_DOC
       = "Backoff time in milliseconds between connection attempts.";
-  private static final String CONNECTION_BACKOFF_DISPLAY
+  public static final String CONNECTION_BACKOFF_DISPLAY
       = "JDBC connection backoff in milliseconds";
   public static final long CONNECTION_BACKOFF_DEFAULT = 10000L;
 

--- a/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
+++ b/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
@@ -22,8 +22,6 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
-
 public class CachedConnectionProvider implements ConnectionProvider {
 
   private static final Logger log = LoggerFactory.getLogger(CachedConnectionProvider.class);
@@ -36,14 +34,6 @@ public class CachedConnectionProvider implements ConnectionProvider {
 
   private int count = 0;
   private Connection connection;
-
-  public CachedConnectionProvider(
-      ConnectionProvider provider
-  ) {
-    this(provider, JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_DEFAULT,
-         JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DEFAULT
-    );
-  }
 
   public CachedConnectionProvider(
       ConnectionProvider provider,

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -364,7 +364,7 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
   }
 
   protected void verifyDataTypeMapping(String expected, Schema schema) {
-    SinkRecordField field = new SinkRecordField(schema, schema.name(),schema.isOptional());
+    SinkRecordField field = new SinkRecordField(schema, schema.name(), schema.isOptional());
     assertEquals(expected, dialect.getSqlType(field));
   }
 

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTypeTest.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTypeTest.java
@@ -17,39 +17,24 @@ package io.confluent.connect.jdbc.dialect;
 
 import java.math.BigDecimal;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
-import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
-import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.source.ColumnMapping;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
 import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.TableId;
 
-import org.apache.kafka.connect.data.Date;
-import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.data.Time;
-import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 import org.mockito.Mock;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -108,7 +93,7 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
 
   @SuppressWarnings("deprecation")
   @Test
-  public void testValueConversionOnNumeric() throws Exception {
+  public void testValueConversion() throws Exception {
     when(columnDefn.precision()).thenReturn(precision);
     when(columnDefn.scale()).thenReturn(scale);
     when(columnDefn.type()).thenReturn(columnType);
@@ -137,6 +122,10 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
     when(resultSet.getShort(1)).thenReturn(SHORT);
     when(resultSet.getByte(1)).thenReturn(BYTE);
     when(resultSet.getDouble(1)).thenReturn(DOUBLE);
+
+    if (expectedValue instanceof String) {
+      when(resultSet.getString(1)).thenReturn((String)expectedValue);
+    }
 
     // Check the converter operates correctly
     ColumnMapping mapping = new ColumnMapping(columnDefn, 1, field);

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
@@ -59,6 +60,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseDialect> {
@@ -480,5 +482,71 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
         "jdbc:acme:db/foo:100?password=****&key1=value1&key2=value2&key3=value3&"
         + "user=smith&password=****&other=value"
     );
+  }
+
+  @Test
+  public void shouldSanitizeUrlWithManyPasswordVariationsInUrlProperties() {
+    assertSanitizedUrl(
+        "jdbc:acme:db/foo:100?"
+        + "javax.net.ssl.keyStorePassword=secret2&"
+        + "password=secret&"
+        + "password&" // incorrect parameter before a non-secret
+        + "key1=value1&"
+        + "key2=value2&"
+        + "key3=value3&"
+        + "passworNotSanitized=not-secret&"
+        + "passwordShouldBeSanitized=value3&"
+        + "javax.net.ssl.trustStorePassword=superSecret&"
+        + "user=smith&"
+        + "Password=secret&"
+        + "other=value",
+        "jdbc:acme:db/foo:100?"
+        + "javax.net.ssl.keyStorePassword=****&"
+        + "password=****&"
+        + "password&"
+        + "key1=value1&"
+        + "key2=value2&"
+        + "key3=value3&"
+        + "passworNotSanitized=not-secret&"
+        + "passwordShouldBeSanitized=****&"
+        + "javax.net.ssl.trustStorePassword=****&"
+        + "user=smith&"
+        + "Password=****&"
+        + "other=value"
+    );
+  }
+
+  @Test
+  public void shouldAddExtraProperties() {
+    // When adding extra properties with the 'connection.' prefix
+    connProps.put("connection.oracle.something", "somethingValue");
+    connProps.put("connection.oracle.else", "elseValue");
+    connProps.put("connection.foo", "bar");
+    // and some other extra properties not prefixed with 'connection.'
+    connProps.put("foo2", "bar2");
+    config = new JdbcSourceConnectorConfig(connProps);
+    dialect = createDialect(config);
+    // and the dialect computes the connection properties
+    Properties props = new Properties();
+    Properties modified = dialect.addConnectionProperties(props);
+    // then the resulting properties
+    // should be the same properties object as what was passed in
+    assertSame(props, modified);
+    // should include props that began with 'connection.' but without prefix
+    assertEquals("somethingValue", modified.get("oracle.something"));
+    assertEquals("elseValue", modified.get("oracle.else"));
+    assertEquals("bar", modified.get("foo"));
+    // should not include any 'connection.*' properties defined by the connector
+    assertFalse(modified.containsKey("url"));
+    assertFalse(modified.containsKey("password"));
+    assertFalse(modified.containsKey("connection.url"));
+    assertFalse(modified.containsKey("connection.password"));
+    // should not include the prefixed props
+    assertFalse(modified.containsKey("connection.oracle.something"));
+    assertFalse(modified.containsKey("connection.oracle.else"));
+    assertFalse(modified.containsKey("connection.foo"));
+    // should not include props not prefixed with 'connection.'
+    assertFalse(modified.containsKey("foo2"));
+    assertFalse(modified.containsKey("connection.foo2"));
   }
 }

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTypeTest.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTypeTest.java
@@ -41,9 +41,9 @@ public class GenericDatabaseDialectTypeTest extends BaseDialectTypeTest<GenericD
             // integers - non optional
             // Parameter range 5-8
             {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 18, 0 },
-            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 8, 0,},
-            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 3, 0,},
-            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 1, 0,},
+            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 8, 0 },
+            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 3, 0 },
+            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 1, 0 },
 
             // integers - optional
             // Parameter range 9-12
@@ -91,6 +91,7 @@ public class GenericDatabaseDialectTypeTest extends BaseDialectTypeTest<GenericD
             {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 18, 127 },
             {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 8, 1 },
             {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 19, 1 },
+
             }
     );
   }

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -240,4 +240,42 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
         + "key2=value2&key3=value3&user=smith&password=****&other=value"
     );
   }
+
+  @Test
+  public void shouldSanitizeUrlWithKerberosCredentialsInUrlProperties() {
+    assertSanitizedUrl(
+        "jdbc:oracle:thin:@myhost:1111/db?"
+        + "password=secret&"
+        + "javax.net.ssl.keyStorePassword=secret2&"
+        + "key1=value1&"
+        + "key2=value2&"
+        + "key3=value3&"
+        + "user=smith&"
+        + "password=secret&"
+        + "passworNotSanitized=not-secret&"
+        + "passwordShouldBeSanitized=value3&"
+        + "javax.net.ssl.trustStorePassword=superSecret&"
+        + "OCINewPassword=secret2&"
+        + "oracle.net.wallet_password=secret3&"
+        + "proxy_password=secret4&"
+        + "PROXY_USER_PASSWORD=secret5&"
+        + "other=value",
+        "jdbc:oracle:thin:@myhost:1111/db?"
+        + "password=****&"
+        + "javax.net.ssl.keyStorePassword=****&"
+        + "key1=value1&"
+        + "key2=value2&"
+        + "key3=value3&"
+        + "user=smith&"
+        + "password=****&"
+        + "passworNotSanitized=not-secret&"
+        + "passwordShouldBeSanitized=****&"
+        + "javax.net.ssl.trustStorePassword=****&"
+        + "OCINewPassword=****&"
+        + "oracle.net.wallet_password=****&"
+        + "proxy_password=****&"
+        + "PROXY_USER_PASSWORD=****&"
+        + "other=value"
+    );
+  }
 }

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.sql.JDBCType;
 import java.sql.Types;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -24,9 +25,16 @@ import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
 
+import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.QuoteMethod;
+import io.confluent.connect.jdbc.util.TableDefinition;
+import io.confluent.connect.jdbc.util.TableDefinitionBuilder;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
@@ -63,10 +71,11 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   public void testCustomColumnConverters() {
     assertColumnConverter(Types.OTHER, PostgreSqlDatabaseDialect.JSON_TYPE_NAME, Schema.STRING_SCHEMA, String.class);
     assertColumnConverter(Types.OTHER, PostgreSqlDatabaseDialect.JSONB_TYPE_NAME, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.OTHER, PostgreSqlDatabaseDialect.UUID_TYPE_NAME, Schema.STRING_SCHEMA, UUID.class);
   }
 
   @Test
-  public void shouldMapDataTypes() {
+  public void shouldMapDataTypesForAddingColumnToTable() {
     verifyDataTypeMapping("SMALLINT", Schema.INT8_SCHEMA);
     verifyDataTypeMapping("SMALLINT", Schema.INT16_SCHEMA);
     verifyDataTypeMapping("INT", Schema.INT32_SCHEMA);
@@ -172,14 +181,65 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   @Test
+  public void shouldBuildInsertStatement() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnB").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnC").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnD").type("varchar", JDBCType.VARCHAR, String.class);
+    TableDefinition tableDefn = builder.build();
+    assertEquals(
+        "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
+        "\"columnC\",\"columnD\") VALUES (?,?,?,?,?,?)",
+        dialect.buildInsertStatement(tableId, pkColumns, columnsAtoD, tableDefn)
+    );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "INSERT INTO myTable (id1,id2,columnA,columnB," +
+        "columnC,columnD) VALUES (?,?,?,?,?,?)",
+        dialect.buildInsertStatement(tableId, pkColumns, columnsAtoD, tableDefn)
+    );
+
+    builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
+    builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
+    tableDefn = builder.build();
+    List<ColumnId> nonPkColumns = new ArrayList<>();
+    nonPkColumns.add(new ColumnId(tableId, "columnA"));
+    nonPkColumns.add(new ColumnId(tableId, "uuidColumn"));
+    nonPkColumns.add(new ColumnId(tableId, "dateColumn"));
+    assertEquals(
+        "INSERT INTO myTable (" +
+        "id1,id2,columnA,uuidColumn,dateColumn" +
+        ") VALUES (?,?,?,?::uuid,?)",
+        dialect.buildInsertStatement(tableId, pkColumns, nonPkColumns, tableDefn)
+    );
+  }
+  @Test
   public void shouldBuildUpsertStatement() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnB").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnC").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnD").type("varchar", JDBCType.VARCHAR, String.class);
+    TableDefinition tableDefn = builder.build();
     assertEquals(
         "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
         "\"columnC\",\"columnD\") VALUES (?,?,?,?,?,?) ON CONFLICT (\"id1\"," +
         "\"id2\") DO UPDATE SET \"columnA\"=EXCLUDED" +
         ".\"columnA\",\"columnB\"=EXCLUDED.\"columnB\",\"columnC\"=EXCLUDED" +
         ".\"columnC\",\"columnD\"=EXCLUDED.\"columnD\"",
-        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD, tableDefn)
     );
 
     quoteIdentfiiers = QuoteMethod.NEVER;
@@ -191,8 +251,48 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         "id2) DO UPDATE SET columnA=EXCLUDED" +
         ".columnA,columnB=EXCLUDED.columnB,columnC=EXCLUDED" +
         ".columnC,columnD=EXCLUDED.columnD",
-        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD, tableDefn)
     );
+
+    builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
+    builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
+    tableDefn = builder.build();
+    List<ColumnId> nonPkColumns = new ArrayList<>();
+    nonPkColumns.add(new ColumnId(tableId, "columnA"));
+    nonPkColumns.add(new ColumnId(tableId, "uuidColumn"));
+    nonPkColumns.add(new ColumnId(tableId, "dateColumn"));
+    assertEquals(
+        "INSERT INTO myTable (" +
+        "id1,id2,columnA,uuidColumn,dateColumn" +
+        ") VALUES (?,?,?,?::uuid,?) ON CONFLICT (id1," +
+        "id2) DO UPDATE SET " +
+        "columnA=EXCLUDED.columnA," +
+        "uuidColumn=EXCLUDED.uuidColumn," +
+        "dateColumn=EXCLUDED.dateColumn",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, nonPkColumns, tableDefn)
+    );
+  }
+
+  @Test
+  public void shouldComputeValueTypeCast() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
+    builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
+    TableDefinition tableDefn = builder.build();
+    ColumnId uuidColumn = tableDefn.definitionForColumn("uuidColumn").id();
+    ColumnId dateColumn = tableDefn.definitionForColumn("dateColumn").id();
+    assertEquals("", dialect.valueTypeCast(tableDefn, columnPK1));
+    assertEquals("", dialect.valueTypeCast(tableDefn, columnPK2));
+    assertEquals("", dialect.valueTypeCast(tableDefn, columnA));
+    assertEquals("::uuid", dialect.valueTypeCast(tableDefn, uuidColumn));
+    assertEquals("", dialect.valueTypeCast(tableDefn, dateColumn));
   }
 
   @Test
@@ -238,7 +338,13 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
   @Test
   public void upsert() {
-    TableId customer = tableId("Customer");
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("Customer");
+    builder.withColumn("id").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("name").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("salary").type("real", JDBCType.FLOAT, String.class);
+    builder.withColumn("address").type("varchar", JDBCType.VARCHAR, String.class);
+    TableDefinition tableDefn = builder.build();
+    TableId customer = tableDefn.id();
     assertEquals(
         "INSERT INTO \"Customer\" (\"id\",\"name\",\"salary\",\"address\") " +
          "VALUES (?,?,?,?) ON CONFLICT (\"id\") DO UPDATE SET \"name\"=EXCLUDED.\"name\"," +
@@ -246,7 +352,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         dialect.buildUpsertQueryStatement(
             customer,
             columns(customer, "id"),
-            columns(customer, "name", "salary", "address")
+            columns(customer, "name", "salary", "address"),
+            tableDefn
         )
     );
 
@@ -256,7 +363,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
             dialect.buildUpsertQueryStatement(
                     customer,
                     columns(customer, "id", "name", "salary", "address"),
-                    columns(customer)
+                    columns(customer),
+                    tableDefn
             )
     );
 
@@ -270,7 +378,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         dialect.buildUpsertQueryStatement(
             customer,
             columns(customer, "id"),
-            columns(customer, "name", "salary", "address")
+            columns(customer, "name", "salary", "address"),
+            tableDefn
         )
     );
 
@@ -280,7 +389,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
             dialect.buildUpsertQueryStatement(
                     customer,
                     columns(customer, "id", "name", "salary", "address"),
-                    columns(customer)
+                    columns(customer),
+                    tableDefn
             )
     );
   }

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTypeTest.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTypeTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.jdbc.dialect;
+
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class PostgreSqlDatabaseDialectTypeTest extends BaseDialectTypeTest<PostgreSqlDatabaseDialect> {
+
+  public static final String UUID_VALUE = "8A52DFE1-CFB9-4C55-B74F-E3D56BBED827";
+
+  @Parameterized.Parameter(7)
+  public String classNameForType;
+
+  @Parameterized.Parameters
+  public static Iterable<Object[]> mapping() {
+    return Arrays.asList(
+        new Object[][] {
+            // UUID - non optional
+            {Schema.Type.STRING, UUID_VALUE, JdbcSourceConnectorConfig.NumericMapping.NONE, NOT_NULLABLE, Types.OTHER, 0, 0, UUID.class.getName() },
+
+            // UUID - optional
+            {Schema.Type.STRING, UUID_VALUE, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.OTHER, 0, 0, UUID.class.getName() },
+        }
+    );
+  }
+
+  @Override
+  protected PostgreSqlDatabaseDialect createDialect() {
+    return new PostgreSqlDatabaseDialect(sourceConfigWithUrl("jdbc:some:db"));
+  }
+
+  @Override
+  public void testValueConversion() throws Exception {
+    when(columnDefn.classNameForType()).thenReturn(classNameForType);
+
+    super.testValueConversion();
+  }
+}

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialectTest.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialectTest.java
@@ -104,6 +104,13 @@ public class SapHanaDatabaseDialectTest extends BaseDialectTest<SapHanaDatabaseD
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
   }
+  
+   @Test
+  public void shouldReturnCurrentTimestampDatabaseQuery() {
+     String expected = "SELECT CURRENT_TIMESTAMP FROM DUMMY";
+     String sql = dialect.currentTimestampDatabaseQuery();
+     assertEquals(expected, sql);
+  }
 
   @Test
   public void shouldBuildAlterTableStatement() {

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -559,12 +559,12 @@ public class BufferedRecordsTest {
     props.put("pk.mode", "record_key");
     props.put("pk.fields", "id");
 
-    // Delete is not enabled, so therefore require non-null key and key schema,
-    // but any combination of value and value schema works
+    // Delete is not enabled, so therefore require non-null key and values with schemas
     assertValidRecord(true, true, true, true);
-    assertValidRecord(true, true, false, true);
-    assertValidRecord(true, true, true, false);
-    assertValidRecord(true, true, false, false);
+    // Fail when ingesting tombstones
+    assertInvalidRecord(true, true, false, true, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, true, true, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, true, false, false, "with a non-null Struct value and non-null Struct schema");
 
     // Fail when null key and null key schema
     assertInvalidRecord(false, false, true, true, "with a null key and null key schema");
@@ -624,20 +624,20 @@ public class BufferedRecordsTest {
     assertValidRecord(true, false, true, true);
     assertValidRecord(false, false, true, true);
 
-    assertValidRecord(true, true, true, false);
-    assertValidRecord(false, true, true, false);
-    assertValidRecord(true, false, true, false);
-    assertValidRecord(false, false, true, false);
+    assertInvalidRecord(true, true, true, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, true, true, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, false, true, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, false, true, false, "with a non-null Struct value and non-null Struct schema");
 
-    assertValidRecord(true, true, false, true);
-    assertValidRecord(false, true, false, true);
-    assertValidRecord(true, false, false, true);
-    assertValidRecord(false, false, false, true);
+    assertInvalidRecord(true, true, false, true, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, true, false, true, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, false, false, true, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, false, false, true, "with a non-null Struct value and non-null Struct schema");
 
-    assertValidRecord(true, true, false, false);
-    assertValidRecord(false, true, false, false);
-    assertValidRecord(true, false, false, false);
-    assertValidRecord(false, false, false, false);
+    assertInvalidRecord(true, true, false, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, true, false, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, false, false, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, false, false, false, "with a non-null Struct value and non-null Struct schema");
   }
 
   @Test

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.integration;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import io.confluent.connect.jdbc.sink.JdbcSinkTask;
+
+import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
+import io.zonky.test.db.postgres.junit.SingleInstancePostgresRule;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Integration tests for writing to Postgres with UUID columns.
+ */
+@Category(IntegrationTest.class)
+public class PostgresDatatypeIT {
+
+  private static Logger log = LoggerFactory.getLogger(PostgresDatatypeIT.class);
+
+  @Rule
+  public SingleInstancePostgresRule pg = EmbeddedPostgresRules.singleInstance();
+
+  private Map<String, String> props;
+  private String tableName;
+  private JdbcSinkTask task;
+
+  @Before
+  public void before() {
+    tableName = "test";
+    props = new HashMap<>();
+    String jdbcURL = String
+        .format("jdbc:postgresql://localhost:%s/postgres", pg.getEmbeddedPostgres().getPort());
+    props.put(JdbcSinkConfig.CONNECTION_URL, jdbcURL);
+    props.put(JdbcSinkConfig.CONNECTION_USER, "postgres");
+    props.put("pk.mode", "none");
+    props.put("topics", tableName);
+  }
+
+  @After
+  public void after() throws SQLException {
+    stopTask();
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        s.execute("DROP TABLE IF EXISTS " + tableName);
+      }
+    }
+    log.info("Dropped table");
+  }
+
+  @Test
+  public void testWriteToTableWithUuidColumn() throws SQLException {
+    createTableWithUuidColumns();
+    startTask();
+    final Schema schema = SchemaBuilder.struct().name("com.example.Person")
+                                       .field("firstname", Schema.STRING_SCHEMA)
+                                       .field("lastname", Schema.STRING_SCHEMA)
+                                       .field("jsonid", Schema.STRING_SCHEMA)
+                                       .field("userid", Schema.STRING_SCHEMA)
+                                       .build();
+    UUID uuid = UUID.randomUUID();
+    String jsonid = "5";
+    final Struct struct = new Struct(schema)
+        .put("firstname", "Christina")
+        .put("lastname", "Brams")
+        .put("jsonid", jsonid)
+        .put("userid", uuid.toString());
+    task.put(Collections.singleton(new SinkRecord(tableName, 1, null, null, schema, struct, 1)));
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        try (ResultSet rs = s.executeQuery("SELECT * FROM " + tableName)) {
+          assertTrue(rs.next());
+          assertEquals(struct.getString("firstname"), rs.getString("firstname"));
+          assertEquals(struct.getString("lastname"), rs.getString("lastname"));
+          assertEquals(struct.getString("jsonid"), rs.getString("jsonid"));
+          assertEquals(struct.getString("userid"), rs.getString("userid"));
+        }
+      }
+    }
+  }
+
+  private void createTableWithUuidColumns() throws SQLException {
+    log.info("Creating table {} with UUID column", tableName);
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      c.setAutoCommit(false);
+      try (Statement s = c.createStatement()) {
+        String sql = String.format(
+            "CREATE TABLE %s(firstName TEXT, lastName TEXT, jsonid json, userid UUID)",
+            tableName
+        );
+        log.info("Executing statement: {}", sql);
+        s.execute(sql);
+        c.commit();
+      }
+    }
+    log.info("Created table {} with UUID column", tableName);
+  }
+
+  private void startTask() {
+    task = new JdbcSinkTask();
+    task.start(props);
+  }
+
+  public void stopTask() {
+    if (task != null) {
+      task.stop();
+    }
+  }
+}

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -34,7 +34,9 @@ import javax.sql.rowset.serial.SerialBlob;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.TimeZone;
@@ -48,18 +50,26 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
-  @Parameterized.Parameters
-  public static Object[] mapping() {
-    return new Object[] { false, true };
+  @Parameterized.Parameters(name="extendedMapping: {0}, timezone: {1}")
+  public static Collection<Object[]> mapping() {
+    return Arrays.asList(new Object[][] {
+        {false, TimeZone.getTimeZone("UTC")},
+        {true, TimeZone.getTimeZone("UTC")},
+        {false, TimeZone.getTimeZone("America/Los_Angeles")},
+        {true, TimeZone.getTimeZone("Asia/Kolkata")}
+    });
   }
 
-  @Parameterized.Parameter
+  @Parameterized.Parameter(0)
   public boolean extendedMapping;
+
+  @Parameterized.Parameter(1)
+  public TimeZone timezone;
 
   @Before
   public void setup() throws Exception {
     super.setup();
-    task.start(singleTableConfig(extendedMapping));
+    task.start(singleTableWithTimezoneConfig(extendedMapping, timezone));
   }
 
   @After
@@ -258,7 +268,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTime() throws Exception {
     GregorianCalendar expected = new GregorianCalendar(1970, Calendar.JANUARY, 1, 23, 3, 20);
-    expected.setTimeZone(TimeZone.getTimeZone("UTC"));
+    expected.setTimeZone(timezone);
     typeConversion("TIME", false, "23:03:20",
                    Time.builder().build(),
                    expected.getTime());
@@ -267,7 +277,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   @Test
   public void testNullableTime() throws Exception {
     GregorianCalendar expected = new GregorianCalendar(1970, Calendar.JANUARY, 1, 23, 3, 20);
-    expected.setTimeZone(TimeZone.getTimeZone("UTC"));
+    expected.setTimeZone(timezone);
     typeConversion("TIME", true, "23:03:20",
                    Time.builder().optional().build(),
                    expected.getTime());
@@ -279,7 +289,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTimestamp() throws Exception {
     GregorianCalendar expected = new GregorianCalendar(1977, Calendar.FEBRUARY, 13, 23, 3, 20);
-    expected.setTimeZone(TimeZone.getTimeZone("UTC"));
+    expected.setTimeZone(timezone);
     typeConversion("TIMESTAMP", false, "1977-02-13 23:03:20",
                    Timestamp.builder().build(),
                    expected.getTime());
@@ -288,7 +298,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   @Test
   public void testNullableTimestamp() throws Exception {
     GregorianCalendar expected = new GregorianCalendar(1977, Calendar.FEBRUARY, 13, 23, 3, 20);
-    expected.setTimeZone(TimeZone.getTimeZone("UTC"));
+    expected.setTimeZone(timezone);
     typeConversion("TIMESTAMP", true, "1977-02-13 23:03:20",
                    Timestamp.builder().optional().build(),
                    expected.getTime());

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -27,6 +27,7 @@ import org.powermock.api.easymock.annotation.Mock;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.NumericMapping;
 
@@ -100,6 +101,14 @@ public class JdbcSourceTaskTestBase {
     } else {
       props.put(JdbcSourceTaskConfig.NUMERIC_PRECISION_MAPPING_CONFIG, "true");
     }
+    return props;
+  }
+
+  protected Map<String, String> singleTableWithTimezoneConfig(
+      boolean completeMapping,
+      TimeZone tz) {
+    Map<String, String> props = singleTableConfig(completeMapping);
+    props.put(JdbcSourceTaskConfig.DB_TIMEZONE_CONFIG, tz.getID());
     return props;
   }
 

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/source/integration/MySQLOOMIT.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/source/integration/MySQLOOMIT.java
@@ -26,10 +26,12 @@ public class MySQLOOMIT extends BaseOOMIntegrationTest {
   public void before() {
     props = new HashMap<>();
     props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG,
-        dbRule.getDBConfiguration().getURL("test") + "?useCursorFetch=true");
+        dbRule.getDBConfiguration().getURL("test"));
     props.put(JdbcSourceConnectorConfig.CONNECTION_USER_CONFIG, "root");
     props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     props.put(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG, "topic_");
+    // Use "extra" connection properties behavior
+    props.put("connection.useCursorFetch", "true");
   }
 
   protected String buildLargeQuery() {

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/util/ColumnDefinitionBuilder.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/util/ColumnDefinitionBuilder.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.sql.JDBCType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ColumnDefinitionBuilder {
+
+  private String columnName;
+  private String typeName;
+  private int jdbcType = JDBCType.INTEGER.ordinal();
+  private int displaySize;
+  private int precision = 10;
+  private int scale = 0;
+  private boolean autoIncremented = false;
+  private boolean caseSensitive = false;
+  private boolean searchable = true;
+  private boolean currency = false;
+  private boolean signedNumbers = false;
+  private boolean isPrimaryKey = false;
+  private ColumnDefinition.Nullability nullability = ColumnDefinition.Nullability.NULL;
+  private ColumnDefinition.Mutability mutability = ColumnDefinition.Mutability.WRITABLE;
+  private String classNameForType;
+
+  public ColumnDefinitionBuilder(String name) {
+    this.columnName = name;
+  }
+
+  public ColumnDefinitionBuilder name(String columnName) {
+    this.columnName = columnName;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder type(String typeName, JDBCType jdbcType, Class<?> clazz) {
+    typeName(typeName);
+    jdbcType(jdbcType);
+    classNameForType(clazz != null ? clazz.getName() : null);
+    return this;
+  }
+
+  public ColumnDefinitionBuilder typeName(String typeName) {
+    this.typeName = typeName;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder jdbcType(JDBCType type) {
+    this.jdbcType = type.ordinal();
+    return this;
+  }
+
+  public ColumnDefinitionBuilder classNameForType(String classNameForType) {
+    this.classNameForType = classNameForType;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder displaySize(int size) {
+    this.displaySize = size;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder precision(int precision) {
+    this.precision = precision;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder scale(int scale) {
+    this.scale = scale;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder autoIncremented(boolean autoIncremented) {
+    this.autoIncremented = autoIncremented;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder caseSensitive(boolean caseSensitive) {
+    this.caseSensitive = caseSensitive;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder searchable(boolean searchable) {
+    this.searchable = searchable;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder currency(boolean currency) {
+    this.currency = currency;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder signedNumbers(boolean signedNumbers) {
+    this.signedNumbers = signedNumbers;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder primaryKey(boolean isPrimaryKey) {
+    this.isPrimaryKey = isPrimaryKey;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder nullable(boolean nullable) {
+    return nullability(
+        nullable ? ColumnDefinition.Nullability.NULL : ColumnDefinition.Nullability.NOT_NULL
+    );
+  }
+
+  public ColumnDefinitionBuilder nullability(ColumnDefinition.Nullability nullability) {
+    this.nullability = nullability;
+    return this;
+  }
+
+  public ColumnDefinitionBuilder mutability(ColumnDefinition.Mutability mutability) {
+    this.mutability = mutability;
+    return this;
+  }
+
+  public ColumnDefinition buildFor(TableId tableId) {
+    return new ColumnDefinition(
+        new ColumnId(tableId, columnName),
+        jdbcType,
+        typeName,
+        classNameForType,
+        nullability,
+        mutability,
+        precision,
+        scale,
+        signedNumbers,
+        displaySize,
+        autoIncremented,
+        caseSensitive,
+        searchable,
+        currency,
+        isPrimaryKey
+    );
+  }
+
+}

--- a/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/util/TableDefinitionBuilder.java
+++ b/kafka-connect-jdbc/src/test/java/io/confluent/connect/jdbc/util/TableDefinitionBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class TableDefinitionBuilder {
+
+  private TableId tableId;
+  private Map<String, ColumnDefinitionBuilder> columnBuilders = new HashMap<>();
+
+  public TableDefinitionBuilder withTable(String tableName) {
+    tableId = new TableId(null, null, tableName);
+    return this;
+  }
+
+  public ColumnDefinitionBuilder withColumn(String columnName) {
+    return columnBuilders.computeIfAbsent(columnName, ColumnDefinitionBuilder::new);
+  }
+
+  public TableDefinition build() {
+    return new TableDefinition(
+        tableId,
+        columnBuilders.values().stream().map(b -> b.buildFor(tableId)).collect(Collectors.toList())
+    );
+  }
+
+}


### PR DESCRIPTION
- Sync changes with base (https://github.com/confluentinc/kafka-connect-jdbc/) to get new configs needed (only updates until Sep 2020)
- Updates connection to config to allow configuration of `connection.attempts` and `connection.backoff.ms` in the sink connector (previously only available to source connector)