### PR TITLE
add support for kafka properties in kafka-wait

### DIFF
--- a/docker/kafka-wait
+++ b/docker/kafka-wait
@@ -2,21 +2,23 @@
 
 max_timeout=32
 
-COMMAND_CONFIG_FILE_PATH="./command_config.properties"
+IS_TEMP=0
 
-if [ -f "$COMMAND_CONFIG_FILE_PATH" ]; then
-    /bin/rm -f "$COMMAND_CONFIG_FILE_PATH"
+if [ -n "$COMMAND_CONFIG_FILE_PATH" ]; then
+    COMMAND_CONFIG_FILE_PATH="$(mktemp)"
+    IS_TEMP=1
 fi
 
-while IFS='=' read -r -d '' n v; do
-
-    if [[ "$n" == "CONNECT_"* ]]; then
-        name="${n/CONNECT_/""}" # remove first "CONNECT_"
-        name="${name,,}" # lower case
-        name="${name//_/"."}" # replace all '_' with '.'
-        echo "$name=$v" >> ${COMMAND_CONFIG_FILE_PATH}
-    fi
-done < <(env -0)
+if [ ! -f "$COMMAND_CONFIG_FILE_PATH" ] || [ $IS_TEMP = 1 ]; then
+    while IFS='=' read -r -d '' n v; do
+        if [[ "$n" == "CONNECT_"* ]]; then
+            name="${n/CONNECT_/""}" # remove first "CONNECT_"
+            name="${name,,}" # lower case
+            name="${name//_/"."}" # replace all '_' with '.'
+            echo "$name=$v" >> ${COMMAND_CONFIG_FILE_PATH}
+        fi
+    done < <(env -0)
+fi
 
 # Check if variables exist
 if [ -z "$CONNECT_BOOTSTRAP_SERVERS" ]; then
@@ -72,4 +74,8 @@ else
     done
 
     echo "Schema registry is available."
+fi
+
+if [ $IS_TEMP = 1 ]; then
+    /bin/rm -f "$COMMAND_CONFIG_FILE_PATH"
 fi

--- a/docker/kafka-wait
+++ b/docker/kafka-wait
@@ -2,6 +2,22 @@
 
 max_timeout=32
 
+COMMAND_CONFIG_FILE_PATH="./command_config.properties"
+
+if [ -f "$COMMAND_CONFIG_FILE_PATH" ]; then
+    /bin/rm -f "$COMMAND_CONFIG_FILE_PATH"
+fi
+
+while IFS='=' read -r -d '' n v; do
+
+    if [[ "$n" == "CONNECT_"* ]]; then
+        name="${n/CONNECT_/""}" # remove first "CONNECT_"
+        name="${name,,}" # lower case
+        name="${name//_/"."}" # replace all '_' with '.'
+        echo "$name=$v" >> ${COMMAND_CONFIG_FILE_PATH}
+    fi
+done < <(env -0)
+
 # Check if variables exist
 if [ -z "$CONNECT_BOOTSTRAP_SERVERS" ]; then
     echo "CONNECT_BOOTSTRAP_SERVERS is not defined"
@@ -11,7 +27,7 @@ else
     tries=10
     timeout=1
     while true; do
-        KAFKA_CHECK=$(kafka-broker-api-versions --bootstrap-server "$CONNECT_BOOTSTRAP_SERVERS" | grep "(id: " | wc -l)
+        KAFKA_CHECK=$(kafka-broker-api-versions --bootstrap-server "$CONNECT_BOOTSTRAP_SERVERS" --command-config "${COMMAND_CONFIG_FILE_PATH}" | grep "(id: " | wc -l)
 
         if [ "$KAFKA_CHECK" -ge "$KAFKA_BROKERS" ]; then
             echo "Kafka brokers available."


### PR DESCRIPTION
## Problem

Kafka-wait launch script does not support SSL and other kafka properties
Related to [#83](https://github.com/RADAR-base/radar-helm-charts/issues/83)

## Solution

Create kafka properties from env vars and use it when querying the brokers for information.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [X] yes
- [ ] no

##### If yes, where?
radar-helm-charts

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests

Testing done by modifying the script on a running instance of connector with an SSL based kafka and running the script successfully.

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 

New release will be made.
