### PR TITLE
fix checking of empty env var in kafka-wait

### DIFF
--- a/docker/kafka-wait
+++ b/docker/kafka-wait
@@ -4,7 +4,7 @@ max_timeout=32
 
 IS_TEMP=0
 
-if [ -n "$COMMAND_CONFIG_FILE_PATH" ]; then
+if [ -z "$COMMAND_CONFIG_FILE_PATH" ]; then
     COMMAND_CONFIG_FILE_PATH="$(mktemp)"
     IS_TEMP=1
 fi


### PR DESCRIPTION
## Problem
The temp file was not being created

## Solution
check if the variable is empty, rather than "not empty" for creating temp file.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
