### PR TITLE
[security] Set docker base image to radarbase/kafka-connect-transform-keyvalue:7.6.0-hotfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG BASE_IMAGE=radarbase/kafka-connect-transform-keyvalue:7.2.1
+ARG BASE_IMAGE=radarbase/kafka-connect-transform-keyvalue:7.6.0-hotfix
 
 FROM --platform=$BUILDPLATFORM maven:3.8-jdk-11 as builder
 

--- a/kafka-connect-jdbc/pom.xml
+++ b/kafka-connect-jdbc/pom.xml
@@ -26,7 +26,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-jdbc</artifactId>
     <packaging>jar</packaging>
-    <version>10.5.2</version>
+    <version>10.5.5</version>
     <name>kafka-connect-jdbc</name>
     <organization>
         <name>Confluent, Inc.</name>


### PR DESCRIPTION
See title
