### PR TITLE
Add support for Sentry monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,11 @@ COPY ./docker/kafka-wait /usr/bin/kafka-wait
 # Load modified launcher
 COPY ./docker/launch /etc/confluent/docker/launch
 
+# Overwrite the log4j configuration to include Sentry monitoring.
+COPY ./docker/log4j.properties.template /etc/confluent/docker/log4j.properties.template
+# Copy Sentry monitoring jars.
+COPY --from=builder /code/kafka-connect-jdbc/target/components/packages/confluentinc-kafka-connect-jdbc-*/confluentinc-kafka-connect-jdbc-*/lib/sentry-* /etc/kafka-connect/jars
+
 USER root
 # create parent directory for storing offsets in standalone mode
 RUN mkdir -p /var/lib/kafka-connect-jdbc/logs

--- a/README.md
+++ b/README.md
@@ -37,3 +37,23 @@ docker-compose up -d --build
 
 Code should be formatted using the [Google Java Code Style Guide](https://google.github.io/styleguide/javaguide.html).
 If you want to contribute a feature or fix browse our [issues](https://github.com/RADAR-base/RADAR-REST-Connector/issues), and please make a pull request.
+
+
+## Sentry monitoring
+
+To enable Sentry monitoring for the JDBC connector, follow these steps:
+
+1. Set a `SENTRY_DSN` environment variable that points to the desired Sentry DSN.
+2. (Optional) Set the `SENTRY_LOG_LEVEL` environment variable to control the minimum log level of
+   events sent to Sentry.
+   The default log level for Sentry is `WARN`. Possible values are `TRACE`, `DEBUG`, `INFO`, `WARN`,
+   and `ERROR`.
+
+For further configuration of Sentry via environmental variables see [here](https://docs.sentry.io/platforms/java/configuration/#configuration-via-the-runtime-environment). For instance:
+
+```
+SENTRY_LOG_LEVEL: 'ERROR'
+SENTRY_DSN: 'https://000000000000.ingest.de.sentry.io/000000000000'
+SENTRY_ATTACHSTACKTRACE: true
+SENTRY_STACKTRACE_APP_PACKAGES: io.confluent.connect.jdbc
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,3 +178,7 @@ services:
       KAFKA_HEAP_OPTS: '-Xms256m -Xmx768m'
       KAFKA_BROKERS: 3
       CONNECT_LOG4J_LOGGERS: 'org.reflections=ERROR'
+      # SENTRY_LOG_LEVEL: 'ERROR'
+      # SENTRY_DSN: 'https://000000000000.ingest.de.sentry.io/000000000000'
+      # SENTRY_ATTACHSTACKTRACE: true
+      # SENTRY_STACKTRACE_APP_PACKAGES: io.confluent.connect.jdbc

--- a/docker/log4j.properties.template
+++ b/docker/log4j.properties.template
@@ -1,0 +1,32 @@
+# This template file was taken from the Confluent Platform distribution and modified to add Sentry support in Docker images.
+# See: https://docs.confluent.io/platform/current/installation/docker/development.html#log-to-external-volumes
+
+log4j.rootLogger={{ env["CONNECT_LOG4J_ROOT_LOGLEVEL"] | default('INFO') }}, stdout{% if env['SENTRY_DSN'] %}, sentryAppender{% endif %}
+
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern ={{ env["CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN"] | default('[%d] %p %m (%c)%n') }}
+
+# Appender for Sentry monitoring
+{% if env['SENTRY_DSN'] %}
+log4j.appender.sentryAppender=io.sentry.log4j.SentryAppender
+log4j.appender.sentryAppender.threshold={{ env['SENTRY_LOG_LEVEL'] | default('ERROR') }}
+{% endif %}
+
+{% set default_loggers = {
+'org.reflections': 'ERROR',
+'org.apache.zookeeper': 'ERROR',
+'org.I0Itec.zkclient': 'ERROR'
+} -%}
+
+{% if env['CONNECT_LOG4J_LOGGERS'] %}
+# loggers from CONNECT_LOG4J_LOGGERS env variable
+{% set loggers = parse_log4j_loggers(env['CONNECT_LOG4J_LOGGERS']) %}
+{% else %}
+# default log levels
+{% set loggers = default_loggers %}
+{% endif %}
+{% for logger,loglevel in loggers.items() %}
+log4j.logger.{{logger}}={{loglevel}}
+{% endfor %}

--- a/kafka-connect-jdbc/pom.xml
+++ b/kafka-connect-jdbc/pom.xml
@@ -86,6 +86,19 @@
     </pluginRepositories>
 
     <dependencies>
+
+        <!-- Fix vulnerabilities in transitive dependencies-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.1.10.4</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>

--- a/kafka-connect-jdbc/pom.xml
+++ b/kafka-connect-jdbc/pom.xml
@@ -277,6 +277,13 @@
             <artifactId>sentry-log4j</artifactId>
             <version>${sentry.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- This log4j version is vulnerable to CVE-2021-44228-->
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/kafka-connect-jdbc/pom.xml
+++ b/kafka-connect-jdbc/pom.xml
@@ -67,6 +67,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.package.home>target/${project.artifactId}-${project.version}-package</project.package.home>
         <testcontainers.version>1.16.2</testcontainers.version>
+        <sentry.version>1.7.30</sentry.version>
     </properties>
 
     <repositories>
@@ -267,6 +268,15 @@
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Application monitoring -->
+        <!-- This dependency is not used by the JDBC connector, but copied into the Docker image (Dockerfile) -->
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-log4j</artifactId>
+            <version>${sentry.version}</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This PR will implement platform observability/monitoring with Sentry. Because of the version of the Confluent base image, we need to use the legacy log4j 1.x implementation. When the SENTRY_DSN environmental variable is not set, the log4j appender is not activated and logs are not sent to Sentry. Includes documentation.