### PR TITLE
feature/open-telemetry

### DIFF
--- a/kafka-connect-jdbc/pom.xml
+++ b/kafka-connect-jdbc/pom.xml
@@ -54,7 +54,7 @@
 
     <properties>
 
-        <project.version>10.8.0</project.version>
+        <project.version>10.9.0</project.version>
 
         <derby.version>10.14.2.0</derby.version>
         <commons-io.version>2.4</commons-io.version>


### PR DESCRIPTION
This PR will add the Sentry Open Telemetry Agent jar to the build. The Open Telemetry jar can be added as a JVM agent during init at the helm chart layer in order to enable Open Telemetry recordings.