### PR TITLE
Fix docker base image registry issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG BASE_IMAGE=radarbase/kafka-connect-transform-keyvalue:7.8.5
+ARG BASE_IMAGE=ghcr.io/radar-base/kafka-connect-transform-keyvalue/kafka-connect-transform-keyvalue:7.8.5
 
 FROM --platform=$BUILDPLATFORM maven:3.8.8-eclipse-temurin-17-focal AS builder
 


### PR DESCRIPTION
## Problem
The registry for the Docker base image was incorrect or misconfigured, causing issues in building or pulling the correct image.

## Solution
Updated the registry configuration to use the correct Docker base image reference.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
This fix will be merged to the master branch. No backporting or rollback is anticipated as this is a standalone fix.